### PR TITLE
Fix exif dependency import

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,5 +23,5 @@ tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-kamadak-exif = "0.6"
+exif = { package = "kamadak-exif", version = "0.6" }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use kamadak_exif::Reader;
+use exif::Reader;
 use serde::Serialize;
 use std::{fs::File, io::BufReader};
 


### PR DESCRIPTION
## Summary
- update the Cargo dependency entry to alias `kamadak-exif` as `exif`
- fix the Rust module import to use the correct `exif::Reader` path

## Testing
- cargo check *(fails: missing system libraries glib-2.0, gobject-2.0, gio-2.0 in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb67b4c8508326bb6121a959d36e6d