### PR TITLE
Handle missing EXIF metadata gracefully

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
-use exif::Reader;
+use exif::{Error as ExifError, Reader};
 use serde::Serialize;
-use std::{fs::File, io::BufReader};
+use std::{
+    fs::File,
+    io::{BufReader, ErrorKind},
+};
 
 #[derive(Serialize)]
 pub struct ExifField {
@@ -13,9 +16,25 @@ pub struct ExifField {
 fn read_exif(path: String) -> Result<Vec<ExifField>, String> {
     let file = File::open(&path).map_err(|error| error.to_string())?;
     let mut reader = BufReader::new(file);
-    let exif = Reader::new()
-        .read_from_container(&mut reader)
-        .map_err(|error| error.to_string())?;
+    let exif = match Reader::new().read_from_container(&mut reader) {
+        Ok(exif) => exif,
+        Err(ExifError::NotFound(_)) => return Ok(Vec::new()),
+        Err(ExifError::InvalidFormat(message)) => {
+            return Err(match message {
+                "Unknown image format" => "The selected file format is not supported.".to_string(),
+                other => other.to_string(),
+            });
+        }
+        Err(ExifError::Io(error)) => {
+            return Err(match error.kind() {
+                ErrorKind::UnexpectedEof => {
+                    "The selected file appears to be truncated or corrupted.".to_string()
+                }
+                _ => error.to_string(),
+            });
+        }
+        Err(other) => return Err(other.to_string()),
+    };
 
     let mut fields: Vec<ExifField> = exif
         .fields()
@@ -32,6 +51,33 @@ fn read_exif(path: String) -> Result<Vec<ExifField>, String> {
     });
 
     Ok(fields)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_path(relative: &str) -> String {
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(relative)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    #[test]
+    fn png_without_exif_returns_empty_result() {
+        let fields = read_exif(fixture_path("app-logo.png"))
+            .expect("PNG without metadata should return an empty result");
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn unsupported_format_returns_friendly_error() {
+        let error = read_exif(fixture_path("README.md"))
+            .expect_err("Non-image files should not produce EXIF data");
+        assert_eq!(error, "The selected file format is not supported.");
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]


### PR DESCRIPTION
## Summary
- treat missing EXIF chunks as an empty result so PNGs and similar formats no longer hard-fail
- provide clearer error strings for truncated or unsupported files
- add regression tests that cover PNGs without metadata and unsupported file types

## Testing
- cargo fmt
- cargo test *(fails: missing gobject-2.0 / glib-2.0 system libraries in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6a94f1d48326b7854cfd464d82fd