### PR TITLE
Add folder scanning for aesthetic score filtering

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,11 +2,16 @@ use exif::{Error as ExifError, Reader};
 use flate2::read::ZlibDecoder;
 use serde::Serialize;
 use std::{
-    fs::File,
+    cmp::Ordering,
+    fs::{self, File},
     io::{Cursor, ErrorKind, Read},
+    path::{Path, PathBuf},
 };
 
 const PNG_SIGNATURE: [u8; 8] = [0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A];
+const SUPPORTED_IMAGE_EXTENSIONS: &[&str] = &[
+    "jpg", "jpeg", "png", "tif", "tiff", "webp", "heic", "heif", "avif", "bmp",
+];
 
 #[derive(Serialize)]
 pub struct ExifField {
@@ -15,53 +20,78 @@ pub struct ExifField {
     value: String,
 }
 
+#[derive(Serialize)]
+pub struct AestheticMatch {
+    path: String,
+    score: f64,
+}
+
 #[tauri::command]
 fn read_exif(path: String) -> Result<Vec<ExifField>, String> {
-    let mut file = File::open(&path).map_err(|error| error.to_string())?;
-    let mut data = Vec::new();
-    file.read_to_end(&mut data)
-        .map_err(|error| error.to_string())?;
+    let path_buf = PathBuf::from(&path);
+    let data = load_file_data(&path_buf)?;
+    collect_fields_from_bytes(&data)
+}
 
-    let mut fields: Vec<ExifField> = Vec::new();
-    {
-        let mut cursor = Cursor::new(&data[..]);
-        match Reader::new().read_from_container(&mut cursor) {
-            Ok(exif) => {
-                fields.extend(exif.fields().map(|field| ExifField {
-                    tag: field.tag.to_string(),
-                    ifd: format!("{:?}", field.ifd_num),
-                    value: field.display_value().with_unit(&exif).to_string(),
-                }));
+#[tauri::command]
+fn find_aesthetic_images(path: String, min_score: f64) -> Result<Vec<AestheticMatch>, String> {
+    if !min_score.is_finite() {
+        return Err("The minimum score must be a valid number.".to_string());
+    }
+
+    let root = PathBuf::from(&path);
+    if !root.exists() {
+        return Err("The selected folder does not exist.".to_string());
+    }
+
+    if root.is_file() {
+        return match analyze_file(&root, min_score)? {
+            Some(result) => Ok(vec![result]),
+            None => Ok(Vec::new()),
+        };
+    }
+
+    if !root.is_dir() {
+        return Err("The selected path is not a folder.".to_string());
+    }
+
+    let mut stack = vec![root];
+    let mut matches = Vec::new();
+
+    while let Some(dir) = stack.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(_) => continue,
+            };
+
+            if file_type.is_dir() {
+                stack.push(path);
+            } else if file_type.is_file() {
+                if let Ok(Some(result)) = analyze_file(&path, min_score) {
+                    matches.push(result);
+                }
             }
-            Err(ExifError::NotFound(_)) => {}
-            Err(ExifError::InvalidFormat(message)) => {
-                return Err(match message {
-                    "Unknown image format" => {
-                        "The selected file format is not supported.".to_string()
-                    }
-                    other => other.to_string(),
-                });
-            }
-            Err(ExifError::Io(error)) => {
-                return Err(match error.kind() {
-                    ErrorKind::UnexpectedEof => {
-                        "The selected file appears to be truncated or corrupted.".to_string()
-                    }
-                    _ => error.to_string(),
-                });
-            }
-            Err(other) => return Err(other.to_string()),
         }
     }
 
-    fields.extend(parse_png_text_chunks(&data));
-
-    fields.sort_by(|a, b| match a.ifd.cmp(&b.ifd) {
-        std::cmp::Ordering::Equal => a.tag.cmp(&b.tag),
-        other => other,
+    matches.sort_by(|a, b| match b.score.partial_cmp(&a.score) {
+        Some(ordering) => ordering,
+        None => Ordering::Equal,
     });
 
-    Ok(fields)
+    Ok(matches)
 }
 
 fn parse_png_text_chunks(data: &[u8]) -> Vec<ExifField> {
@@ -231,6 +261,113 @@ fn decode_latin1(bytes: &[u8]) -> String {
     bytes.iter().map(|&byte| byte as char).collect()
 }
 
+fn load_file_data(path: &Path) -> Result<Vec<u8>, String> {
+    let mut file = File::open(path).map_err(|error| error.to_string())?;
+    let mut data = Vec::new();
+    file.read_to_end(&mut data)
+        .map_err(|error| error.to_string())?;
+    Ok(data)
+}
+
+fn collect_fields_from_bytes(data: &[u8]) -> Result<Vec<ExifField>, String> {
+    let mut fields: Vec<ExifField> = Vec::new();
+    {
+        let mut cursor = Cursor::new(&data[..]);
+        match Reader::new().read_from_container(&mut cursor) {
+            Ok(exif) => {
+                fields.extend(exif.fields().map(|field| ExifField {
+                    tag: field.tag.to_string(),
+                    ifd: format!("{:?}", field.ifd_num),
+                    value: field.display_value().with_unit(&exif).to_string(),
+                }));
+            }
+            Err(ExifError::NotFound(_)) => {}
+            Err(ExifError::InvalidFormat(message)) => {
+                return Err(match message {
+                    "Unknown image format" => {
+                        "The selected file format is not supported.".to_string()
+                    }
+                    other => other.to_string(),
+                });
+            }
+            Err(ExifError::Io(error)) => {
+                return Err(match error.kind() {
+                    ErrorKind::UnexpectedEof => {
+                        "The selected file appears to be truncated or corrupted.".to_string()
+                    }
+                    _ => error.to_string(),
+                });
+            }
+            Err(other) => return Err(other.to_string()),
+        }
+    }
+
+    fields.extend(parse_png_text_chunks(data));
+
+    fields.sort_by(|a, b| match a.ifd.cmp(&b.ifd) {
+        Ordering::Equal => a.tag.cmp(&b.tag),
+        other => other,
+    });
+
+    Ok(fields)
+}
+
+fn analyze_file(path: &Path, min_score: f64) -> Result<Option<AestheticMatch>, String> {
+    if !is_supported_image(path) {
+        return Ok(None);
+    }
+
+    let data = load_file_data(path)?;
+    let fields = match collect_fields_from_bytes(&data) {
+        Ok(fields) => fields,
+        Err(_) => return Ok(None),
+    };
+
+    if let Some(score) = extract_aesthetic_score(&fields) {
+        if score >= min_score {
+            return Ok(Some(AestheticMatch {
+                path: path.to_string_lossy().into_owned(),
+                score,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+fn is_supported_image(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| {
+            let lower = ext.to_ascii_lowercase();
+            SUPPORTED_IMAGE_EXTENSIONS
+                .iter()
+                .any(|candidate| *candidate == lower)
+        })
+        .unwrap_or(false)
+}
+
+fn extract_aesthetic_score(fields: &[ExifField]) -> Option<f64> {
+    fields
+        .iter()
+        .filter(|field| is_aesthetic_tag(&field.tag))
+        .filter_map(|field| parse_score_value(&field.value))
+        .find(|score| score.is_finite())
+}
+
+fn is_aesthetic_tag(tag: &str) -> bool {
+    let normalized = tag.trim().to_ascii_lowercase().replace(['_', '-'], " ");
+    normalized == "aesthetic score" || normalized == "aestheticscore"
+}
+
+fn parse_score_value(value: &str) -> Option<f64> {
+    value
+        .split(|c: char| !(c.is_ascii_digit() || matches!(c, '.' | '-' | '+')))
+        .filter(|segment| !segment.is_empty())
+        .filter_map(|segment| segment.parse::<f64>().ok())
+        .find(|score| score.is_finite())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -296,6 +433,39 @@ mod tests {
         data
     }
 
+    fn build_png_with_aesthetic_score(score: &str) -> Vec<u8> {
+        fn png_chunk(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+            let mut chunk = Vec::new();
+            chunk.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+            chunk.extend_from_slice(kind);
+            chunk.extend_from_slice(payload);
+            chunk.extend_from_slice(&[0, 0, 0, 0]);
+            chunk
+        }
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&PNG_SIGNATURE);
+
+        let mut ihdr = Vec::new();
+        ihdr.extend_from_slice(&1u32.to_be_bytes());
+        ihdr.extend_from_slice(&1u32.to_be_bytes());
+        ihdr.push(8);
+        ihdr.push(2);
+        ihdr.push(0);
+        ihdr.push(0);
+        ihdr.push(0);
+        data.extend(png_chunk(b"IHDR", &ihdr));
+
+        let mut payload = Vec::new();
+        payload.extend_from_slice(b"Aesthetic score");
+        payload.push(0);
+        payload.extend_from_slice(score.as_bytes());
+        data.extend(png_chunk(b"tEXt", &payload));
+
+        data.extend(png_chunk(b"IEND", &[]));
+        data
+    }
+
     #[test]
     fn png_without_exif_returns_empty_result() {
         let fields = read_exif(fixture_path("app-logo.png"))
@@ -353,6 +523,38 @@ mod tests {
             .value
             .contains("Translated keyword: Beschreibung"));
     }
+
+    #[test]
+    fn folder_scan_filters_by_aesthetic_score() {
+        let mut dir = std::env::temp_dir();
+        dir.push(format!(
+            "exif_viewer_aesthetic_scan_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).expect("should create temporary directory");
+
+        let high_path = dir.join("high.png");
+        std::fs::write(&high_path, build_png_with_aesthetic_score("0.82"))
+            .expect("should write high score PNG");
+
+        let low_path = dir.join("low.png");
+        std::fs::write(&low_path, build_png_with_aesthetic_score("0.25"))
+            .expect("should write low score PNG");
+
+        let results = find_aesthetic_images(dir.to_string_lossy().into_owned(), 0.5)
+            .expect("folder scan should succeed");
+
+        std::fs::remove_dir_all(&dir).ok();
+
+        assert_eq!(results.len(), 1);
+        let result = &results[0];
+        assert!(result.path.ends_with("high.png"));
+        assert!((result.score - 0.82).abs() < f64::EPSILON);
+    }
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -360,7 +562,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![read_exif])
+        .invoke_handler(tauri::generate_handler![read_exif, find_aesthetic_images])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }


### PR DESCRIPTION
## Summary
- add a Tauri command that recursively scans supported images in a folder and filters on the "Aesthetic score" metadata value
- surface a new UI section to choose a folder, set a minimum score, and list matching files in a table
- extend the Rust test suite with coverage for the folder scan and reusable PNG fixtures

## Testing
- npm run build
- cargo test *(fails: missing system library gobject-2.0 required by dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68cc60060798832680964194d357a293